### PR TITLE
Add danger toast if converted value is NaN

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -117,12 +117,15 @@
     $: convertedValue = $selectedActivity && duration ? Math.round(duration * $selectedActivity[$selectedUnit.unit] * 0.1 * 100) / 100 : 0;
 
     const copy = () => {
+        if (isNaN(convertedValue)) {
+            Toast.create({ message: 'Invalid duration value!', type: 'is-danger', position: 'is-top', duration: 2000 });
+            return;
+        }
         const app = new CopyClipBoard({
             target: document.getElementById('clipboard'),
             props: {name: convertedValue},
         });
         app.$destroy();
-        Toast.create({ message: 'Copied to clipboard!', type: 'is-success', position: 'is-top', duration: 2000 });
     }
 
 


### PR DESCRIPTION
If the converted value is `NaN`, a danger toast is brought up to indicate an error and the copy to clipboard operation is not carried.

Another solution could be to change the attribute `type` to `number` and add the attribute `step=0.01` so the converted value would be `0` if the duration value is anything else than a number. The optimal solution would be to prevent anything but numbers and period with a regexp like `[0-9]*\.?[0-9]*`, but I was not able to achieve that solution

### Screenshot
![image](https://user-images.githubusercontent.com/14026304/234438059-19b4eced-5701-47da-ad9a-990223b1095c.png)
